### PR TITLE
Use of collections.empty and direct use of sjsonnet.Std

### DIFF
--- a/src/main/java/com/datasonnet/commands/Validate.java
+++ b/src/main/java/com/datasonnet/commands/Validate.java
@@ -5,7 +5,7 @@ import com.datasonnet.Mapper;
 import picocli.CommandLine;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(
@@ -26,7 +26,7 @@ public class Validate implements Callable<Void> {
 
     @Override
     public Void call() throws Exception {
-        Mapper mapper = new Mapper(Main.readFile(datasonnet), new ArrayList<>(), !includesFunction);
+        Mapper mapper = new Mapper(Main.readFile(datasonnet), Collections.emptyList(), !includesFunction);
         System.out.println("Validates!");
         return null;
     }

--- a/src/main/scala/com/datasonnet/Mapper.scala
+++ b/src/main/scala/com/datasonnet/Mapper.scala
@@ -1,6 +1,7 @@
 package com.datasonnet
 
 import java.io.{File, PrintWriter, StringWriter}
+import java.util.Collections
 
 import com.datasonnet.wrap.{DataSonnetPath, NoFileEvaluator}
 import fastparse.{IndexedParserInput, Parsed}
@@ -120,7 +121,7 @@ class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imp
   def lineOffset = if (needsWrapper) 1 else 0
 
   def this(jsonnet: String, argumentNames: java.lang.Iterable[String], needsWrapper: Boolean) {
-    this(jsonnet, argumentNames, new java.util.HashMap[String, String](), needsWrapper)
+    this(jsonnet, argumentNames, Collections.emptyMap(), needsWrapper)
   }
 
   def importer(parent: Path, path: String): Option[(Path, String)] = for {

--- a/src/main/scala/com/datasonnet/PortX.scala
+++ b/src/main/scala/com/datasonnet/PortX.scala
@@ -74,9 +74,9 @@ object PortX {
                           "data" -> None,
                           "mimeType" -> None,
                           "params" -> Some(Expr.Null(0))) { (args, ev) =>
-        val data = args("data").asInstanceOf[Val.Str].value
-        val mimeType = args("mimeType").asInstanceOf[Val.Str].value
-        val params = if (args("params") == Val.Null) null else args("params").asInstanceOf[Val.Obj]
+        val data = args("data").cast[Val.Str].value
+        val mimeType = args("mimeType").cast[Val.Str].value
+        val params = if (args("params") == Val.Null) null else args("params").cast[Val.Obj]
         read(data, mimeType, params, ev)
       },
       builtinWithDefaults("write",
@@ -84,8 +84,8 @@ object PortX {
         "mimeType" -> None,
         "params" -> Some(Expr.Null(0))) { (args, ev) =>
         val data = args("data")
-        val mimeType = args("mimeType").asInstanceOf[Val.Str].value
-        val params = if (args("params") == Val.Null) null else args("params").asInstanceOf[Val.Obj]
+        val mimeType = args("mimeType").cast[Val.Str].value
+        val params = if (args("params") == Val.Null) null else args("params").cast[Val.Obj]
         write(data, mimeType, params, ev)
       },
 

--- a/src/main/scala/com/datasonnet/PortX.scala
+++ b/src/main/scala/com/datasonnet/PortX.scala
@@ -5,8 +5,9 @@ import java.time.{Instant, Period, ZoneId, ZoneOffset}
 
 import com.datasonnet
 import com.datasonnet.spi.{DataFormatPlugin, DataFormatService, UnsupportedMimeTypeException, UnsupportedParameterException}
-import com.datasonnet.wrap.Library.{builtin, builtin0, library}
-import sjsonnet.Std.builtinWithDefaults
+import com.datasonnet.wrap.Library.library
+import sjsonnet.ReadWriter.StringRead
+import sjsonnet.Std._
 import sjsonnet.{EvalScope, Expr, Materializer, Val}
 
 import scala.util.Failure
@@ -31,8 +32,14 @@ object PortX {
           datetimeObj.format(DateTimeFormatter.ofPattern(outputFormat))
       },
 
-      builtin("compare", "datetime1", "format1", "datetime2", "format2") {
-        (ev, fs, datetime1: String, format1: String, datetime2: String, format2: String) =>
+      builtin0("compare", "datetime1", "format1", "datetime2", "format2") {
+        (vals, ev, fs) =>
+          val strValSeq = validate(vals, ev, fs, Array(StringRead, StringRead, StringRead, StringRead))
+          val datetime1 = strValSeq(0).asInstanceOf[String]
+          val format1 = strValSeq(1).asInstanceOf[String]
+          val datetime2 = strValSeq(2).asInstanceOf[String]
+          val format2 = strValSeq(3).asInstanceOf[String]
+
           val datetimeObj1 = java.time.ZonedDateTime.parse(datetime1, DateTimeFormatter.ofPattern(format1))
           val datetimeObj2 = java.time.ZonedDateTime.parse(datetime2, DateTimeFormatter.ofPattern(format2))
           datetimeObj1.compareTo(datetimeObj2)
@@ -103,8 +110,14 @@ object PortX {
           datetimeObj.format(DateTimeFormatter.ofPattern(outputFormat))
       },
 
-      builtin("compare", "datetime1", "format1", "datetime2", "format2") {
-        (ev, fs, datetime1: String, format1: String, datetime2: String, format2: String) =>
+      builtin0("compare", "datetime1", "format1", "datetime2", "format2") {
+        (vals, ev, fs) =>
+          val strValSeq = validate(vals, ev, fs, Array(StringRead, StringRead, StringRead, StringRead))
+          val datetime1 = strValSeq(0).asInstanceOf[String]
+          val format1 = strValSeq(1).asInstanceOf[String]
+          val datetime2 = strValSeq(2).asInstanceOf[String]
+          val format2 = strValSeq(3).asInstanceOf[String]
+
           val datetimeObj1 = java.time.LocalDateTime.parse(datetime1, DateTimeFormatter.ofPattern(format1))
           val datetimeObj2 = java.time.LocalDateTime.parse(datetime2, DateTimeFormatter.ofPattern(format2))
           datetimeObj1.compareTo(datetimeObj2)

--- a/src/main/scala/com/datasonnet/wrap/Library.scala
+++ b/src/main/scala/com/datasonnet/wrap/Library.scala
@@ -1,102 +1,10 @@
 package com.datasonnet.wrap
 
-import java.io.StringWriter
-import java.util.Base64
-
 import sjsonnet.Expr.Member.Visibility
-import sjsonnet.Expr.Params
 import sjsonnet._
-
-import scala.collection.mutable.ArrayBuffer
-import scala.collection.compat._
 
 
 object Library {
-  def validate(vs: Array[Val],
-               ev: EvalScope,
-               fs: FileScope,
-               rs: Array[ReadWriter[_]]) = {
-    for(i <- vs.indices) yield {
-      val v = vs(i)
-      val r = rs(i)
-      r.apply(v, ev, fs) match {
-        case Left(err) => throw new Error.Delegate("Wrong parameter type: expected " + err + ", got " + v.prettyName)
-        case Right(x) => x
-      }
-    }
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter](name: String, p1: String)
-                                            (eval: (EvalScope, FileScope, T1) => R): (String, Val.Func) = builtin0(name, p1){ (vs, ev, fs) =>
-    val Seq(v: T1) = validate(vs, ev, fs, Array(implicitly[ReadWriter[T1]]))
-    eval(ev, fs, v)
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter](name: String, p1: String, p2: String)
-                                                            (eval: (EvalScope, FileScope, T1, T2) => R): (String, Val.Func) = builtin0(name, p1, p2){ (vs, ev, fs) =>
-    val Seq(v1: T1, v2: T2) = validate(vs, ev, fs, Array(implicitly[ReadWriter[T1]], implicitly[ReadWriter[T2]]))
-    eval(ev, fs, v1, v2)
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter](name: String, p1: String, p2: String, p3: String)
-                                                                            (eval: (EvalScope, FileScope, T1, T2, T3) => R): (String, Val.Func) = builtin0(name, p1, p2, p3){ (vs, ev, fs) =>
-    val Seq(v1: T1, v2: T2, v3: T3) = validate(vs, ev, fs, Array(implicitly[ReadWriter[T1]], implicitly[ReadWriter[T2]], implicitly[ReadWriter[T3]]))
-    eval(ev, fs, v1, v2, v3)
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter, T4: ReadWriter](name: String, p1: String, p2: String, p3: String, p4: String)
-                                                                            (eval: (EvalScope, FileScope, T1, T2, T3, T4) => R): (String, Val.Func) = builtin0(name, p1, p2, p3, p4){ (vs, ev, fs) =>
-    val Seq(v1: T1, v2: T2, v3: T3, v4: T4) = validate(vs, ev, fs, Array(implicitly[ReadWriter[T1]], implicitly[ReadWriter[T2]], implicitly[ReadWriter[T3]], implicitly[ReadWriter[T4]]))
-    eval(ev, fs, v1, v2, v3, v4)
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter, T4: ReadWriter, T5: ReadWriter](name: String, p1: String, p2: String, p3: String, p4: String, p5: String)
-                                                                                            (eval: (EvalScope, FileScope, T1, T2, T3, T4, T5) => R): (String, Val.Func) = builtin0(name, p1, p2, p3, p4, p5){ (vs, ev, fs) =>
-    val Seq(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) = validate(vs, ev, fs, Array(implicitly[ReadWriter[T1]], implicitly[ReadWriter[T2]], implicitly[ReadWriter[T3]], implicitly[ReadWriter[T4]], implicitly[ReadWriter[T5]]))
-    eval(ev, fs, v1, v2, v3, v4, v5)
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter, T4: ReadWriter, T5: ReadWriter, T6: ReadWriter](name: String, p1: String, p2: String, p3: String, p4: String, p5: String, p6: String)
-                                                                                                            (eval: (EvalScope, FileScope, T1, T2, T3, T4, T5, T6) => R): (String, Val.Func) = builtin0(name, p1, p2, p3, p4, p5, p6){ (vs, ev, fs) =>
-    val Seq(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) = validate(vs, ev, fs, Array(implicitly[ReadWriter[T1]], implicitly[ReadWriter[T2]], implicitly[ReadWriter[T3]], implicitly[ReadWriter[T4]], implicitly[ReadWriter[T5]], implicitly[ReadWriter[T6]]))
-    eval(ev, fs, v1, v2, v3, v4, v5, v6)
-  }
-
-  def builtin0[R: ReadWriter](name: String, params: String*)(eval: (Array[Val], EvalScope, FileScope) => R) = {
-    val paramData = params.zipWithIndex.map{case (k, i) => (k, None, i)}.toArray
-    val paramIndices = params.indices.toArray
-    name -> Val.Func(
-      None,
-      Params(paramData),
-      {(scope, thisFile, ev, fs, outerOffset) =>
-        implicitly[ReadWriter[R]].write(
-          eval(paramIndices.map(i => scope.bindings(i).get.force), ev, fs)
-        )
-      }
-    )
-  }
-  /**
-    * Helper function that can define a built-in function with default parameters
-    *
-    * Arguments of the eval function are (args, ev)
-    */
-  def builtinWithDefaults[R: ReadWriter](name: String, params: (String, Option[Expr])*)
-                                        (eval: (Map[String, Val], EvalScope) => R): (String, Val.Func) = {
-    val indexedParams = params.zipWithIndex.map{case ((k, v), i) => (k, v, i)}.toArray
-    val indexedParamKeys = params.zipWithIndex.map{case ((k, v), i) => (k, i)}
-    name -> Val.Func(
-      None,
-      Params(indexedParams),
-      { (scope, thisFile, ev, fs, outerOffset) =>
-        val args = indexedParamKeys.map {case (k, i) => k -> scope.bindings(i).get.force }.toMap
-        implicitly[ReadWriter[R]].write(eval(args, ev))
-      },
-      { (expr, scope, eval) =>
-        eval.visitExpr(expr)(scope, new FileScope(null, Map.empty))
-      }
-    )
-  }
-
   def library(functions: (String, Val.Func)*): Val.Obj = new Val.Obj(
     functions
       .map{

--- a/src/test/java/com/datasonnet/CSVReaderTest.java
+++ b/src/test/java/com/datasonnet/CSVReaderTest.java
@@ -6,8 +6,7 @@ import com.datasonnet.Mapper;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -22,8 +21,8 @@ public class CSVReaderTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper("local csvInput = DS.Formats.read(payload, \"application/csv\"); { fName: csvInput[0][\"First Name\"] }", new ArrayList<>(), true);
-        Document mapped = mapper.transform(data, new HashMap<>(), "application/json");
+        Mapper mapper = new Mapper("local csvInput = DS.Formats.read(payload, \"application/csv\"); { fName: csvInput[0][\"First Name\"] }", Collections.emptyList(), true);
+        Document mapped = mapper.transform(data, Collections.emptyMap(), "application/json");
 
         assertEquals("{\"fName\":\"Eugene\"}", mapped.contents());
     }
@@ -38,8 +37,8 @@ public class CSVReaderTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
-        Document mapped = mapper.transform(data, new HashMap<>(), "application/json");
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        Document mapped = mapper.transform(data, Collections.emptyMap(), "application/json");
 
         assertEquals("{\"fName\":\"Eugene\",\"num\":\"234\"}", mapped.contents());
     }

--- a/src/test/java/com/datasonnet/CSVWriterTest.java
+++ b/src/test/java/com/datasonnet/CSVWriterTest.java
@@ -7,8 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -24,8 +23,8 @@ public class CSVWriterTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/csv\")", new ArrayList<>(), true);
-        Document mapped = mapper.transform(data, new HashMap<>(), "application/csv");
+        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/csv\")", Collections.emptyList(), true);
+        Document mapped = mapper.transform(data, Collections.emptyMap(), "application/csv");
         String expected = TestResourceReader.readFileAsString("writeCSVTest.csv");
         assertEquals(expected.trim(), mapped.contents().trim());
     }
@@ -40,8 +39,8 @@ public class CSVWriterTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
-        Document mapped = mapper.transform(data, new HashMap<>(), "application/csv");
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        Document mapped = mapper.transform(data, Collections.emptyMap(), "application/csv");
         String expected = TestResourceReader.readFileAsString("writeCSVExtTest.csv");
         assertEquals(expected.trim(), mapped.contents().trim());
     }

--- a/src/test/java/com/datasonnet/CryptoTest.java
+++ b/src/test/java/com/datasonnet/CryptoTest.java
@@ -3,8 +3,7 @@ package com.datasonnet;
 import com.datasonnet.Mapper;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -13,32 +12,32 @@ public class CryptoTest {
 
     @Test
     void testHash() {
-        Mapper mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD2\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD2\")", Collections.emptyList(), true);
         String hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("4227ce10dca49dd2d0ba3f438d1ea9f3".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD5\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD5\")", Collections.emptyList(), true);
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("68e109f0f40ca72a15e05cc22786f8e6".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-1\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-1\")", Collections.emptyList(), true);
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("db8ac1c259eb89d4a131b253bacfca5f319d54f2".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-256\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-256\")", Collections.emptyList(), true);
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-384\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-384\")", Collections.emptyList(), true);
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("293cd96eb25228a6fb09bfa86b9148ab69940e68903cbc0527a4fb150eec1ebe0f1ffce0bc5e3df312377e0a68f1950a".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-512\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-512\")", Collections.emptyList(), true);
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("8ae6ae71a75d3fb2e0225deeb004faf95d816a0a58093eb4cb5a3aa0f197050d7a4dc0a2d5c6fbae5fb5b0d536a0a9e6b686369fa57a027687c3630321547596".equals(hash));
 
         try {
-            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")", new ArrayList<>(), true);
+            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")", Collections.emptyList(), true);
             hash = mapper.transform("{}").replaceAll("\"", "");
             fail("This should fail with NoSuchAlgorithmException");
         } catch (Exception e) {
@@ -49,20 +48,20 @@ public class CryptoTest {
 
     @Test
     void testHMAC() {
-        Mapper mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA1\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA1\")", Collections.emptyList(), true);
         String hmac = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("91f27e2a84a9804b101257a2edfd121b02917e1a".equals(hmac));
 
-        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA256\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA256\")", Collections.emptyList(), true);
         hmac = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("7854220ef827b07529509f68f391a80bf87fff328dbda140ed582520a1372dc1".equals(hmac));
 
-        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA512\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA512\")", Collections.emptyList(), true);
         hmac = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("0acbc9c5d0828f3bc9c30e311311073089f969d7ccbfacc457c8da289bc163fee911f75b3b018b2d0c7a09e758b970fcdc6b6488118fd52dbbf31b9ee0415d4c".equals(hmac));
 
         try {
-            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")", new ArrayList<>(), true);
+            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")", Collections.emptyList(), true);
             hmac = mapper.transform("{}").replaceAll("\"", "");
             fail("This should fail with NoSuchAlgorithmException");
         } catch (Exception e) {
@@ -73,11 +72,11 @@ public class CryptoTest {
 
     @Test
     void testEncrypt() {
-        Mapper mapper = new Mapper("DS.Crypto.encrypt(\"HelloWorld\", \"DataSonnet123\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.Crypto.encrypt(\"HelloWorld\", \"DataSonnet123\")", Collections.emptyList(), true);
         String encrypted = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("HdK8opktKiK3ero0RJiYbA==".equals(encrypted));
 
-        mapper = new Mapper("DS.Crypto.decrypt(\"HdK8opktKiK3ero0RJiYbA==\", \"DataSonnet123\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.Crypto.decrypt(\"HdK8opktKiK3ero0RJiYbA==\", \"DataSonnet123\")", Collections.emptyList(), true);
         String decrypted = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("HelloWorld".equals(decrypted));
     }

--- a/src/test/java/com/datasonnet/ImportTest.java
+++ b/src/test/java/com/datasonnet/ImportTest.java
@@ -3,7 +3,7 @@ package com.datasonnet;
 import com.datasonnet.util.TestResourceReader;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ImportTest {
     @Test
     void simpleImport() {
-        Mapper mapper = new Mapper("import 'output.json'", new ArrayList<>(), new HashMap<String, String>() {{ put("output.json", "{\"a\": 5}"); }},true);
+        Mapper mapper = new Mapper("import 'output.json'", Collections.emptyList(), new HashMap<String, String>() {{ put("output.json", "{\"a\": 5}"); }},true);
         String result = mapper.transform("{}");
         assertEquals("{\"a\":5}", result);
     }
@@ -21,7 +21,7 @@ public class ImportTest {
     @Test
     void importParseErrorLineNumber() {
         try {
-            Mapper mapper = new Mapper("import 'output.json'", new ArrayList<>(), new HashMap<String, String>() {{
+            Mapper mapper = new Mapper("import 'output.json'", Collections.emptyList(), new HashMap<String, String>() {{
                 put("output.json", "a b");
             }}, true);
             String result = mapper.transform("{}");
@@ -34,7 +34,7 @@ public class ImportTest {
     @Test
     void importExecuteErrorLineNumber() {
         try {
-            Mapper mapper = new Mapper("import 'output.json'", new ArrayList<>(), new HashMap<String, String>() {{
+            Mapper mapper = new Mapper("import 'output.json'", Collections.emptyList(), new HashMap<String, String>() {{
                 put("output.json", "a.b");
             }}, true);
             String result = mapper.transform("{}");
@@ -50,7 +50,7 @@ public class ImportTest {
         try {
             final String lib = TestResourceReader.readFileAsString("importTest.libsonnet");
             final String json = TestResourceReader.readFileAsString("importLibsonnetTest.json");
-            Mapper mapper = new Mapper("local testlib = import 'importTest.libsonnet'; local teststr = import 'importLibsonnetTest.json'; { greeting: testlib.sayHello('World') }", new ArrayList<>(), new HashMap<String, String>() {{
+            Mapper mapper = new Mapper("local testlib = import 'importTest.libsonnet'; local teststr = import 'importLibsonnetTest.json'; { greeting: testlib.sayHello('World') }", Collections.emptyList(), new HashMap<String, String>() {{
                 put("importTest.libsonnet", lib);
                 put("importLibsonnetTest.json", json);
             }}, true);
@@ -63,7 +63,7 @@ public class ImportTest {
     void importLibsonnetFail() throws Exception {
         try {
             final String libErr = TestResourceReader.readFileAsString("importTestFail.libsonnet");
-            Mapper mapper = new Mapper("local testlib = import 'importTestFail.libsonnet'; { greeting: testlib.sayHello('World') }", new ArrayList<>(), new HashMap<String, String>() {{
+            Mapper mapper = new Mapper("local testlib = import 'importTestFail.libsonnet'; { greeting: testlib.sayHello('World') }", Collections.emptyList(), new HashMap<String, String>() {{
                 put("importTestFail.libsonnet", libErr);
             }}, true);
             fail("This test should fail");

--- a/src/test/java/com/datasonnet/JsonPathTest.java
+++ b/src/test/java/com/datasonnet/JsonPathTest.java
@@ -6,8 +6,7 @@ import com.datasonnet.Mapper;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 public class JsonPathTest {
 
@@ -15,8 +14,8 @@ public class JsonPathTest {
     void testJsonPathSelector() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("jsonPathTest.json");
 
-        Mapper mapper = new Mapper("DS.JsonPath.select(payload, \"$..book[-2:]..author\")[0]", new ArrayList<>(), true);
-        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper("DS.JsonPath.select(payload, \"$..book[-2:]..author\")[0]", Collections.emptyList(), true);
+        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").contents();
 
         assertEquals(mappedJson, "\"Herman Melville\"");
     }
@@ -25,8 +24,8 @@ public class JsonPathTest {
     void testJsonPathArrSelector() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("jsonPathArrTest.json");
 
-        Mapper mapper = new Mapper("std.length(DS.JsonPath.select(payload, \"$..language[?(@.name == 'Java')]\")) > 0", new ArrayList<>(), true);
-        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper("std.length(DS.JsonPath.select(payload, \"$..language[?(@.name == 'Java')]\")) > 0", Collections.emptyList(), true);
+        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").contents();
 
         assertEquals(mappedJson, "true");
     }

--- a/src/test/java/com/datasonnet/LocalDateTimeTest.java
+++ b/src/test/java/com/datasonnet/LocalDateTimeTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,7 +14,7 @@ public class LocalDateTimeTest {
 
     @Test
     void testOffset() {
-        Mapper mapper = new Mapper("DS.LocalDateTime.offset(\"2019-07-22T21:00:00\", \"P1Y1D\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.offset(\"2019-07-22T21:00:00\", \"P1Y1D\")", Collections.emptyList(), true);
         String offsetDate = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("2020-07-23T21:00:00".equals(offsetDate));
 //        System.out.println("Offset date is " + offsetDate);
@@ -25,7 +24,7 @@ public class LocalDateTimeTest {
     void testNow() {
         Instant before = Instant.now();
 
-        Mapper mapper = new Mapper("DS.LocalDateTime.now()", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.now()", Collections.emptyList(), true);
         // getting rid of quotes so the Instant parser works
         String mapped = mapper.transform("{}").replaceAll("\"", "");
         String today = java.time.LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
@@ -38,7 +37,7 @@ public class LocalDateTimeTest {
 
     @Test
     void testFormat() {
-        Mapper mapper = new Mapper("DS.LocalDateTime.format(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"d MMM uuuu\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.format(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"d MMM uuuu\")", Collections.emptyList(), true);
         String formattedDate = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("4 Jul 2019".equals(formattedDate));
@@ -46,7 +45,7 @@ public class LocalDateTimeTest {
 
     @Test
     void testCompare() {
-        Mapper mapper = new Mapper("DS.LocalDateTime.compare(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.compare(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\")", Collections.emptyList(), true);
         String compareResult = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("0".equals(compareResult));

--- a/src/test/java/com/datasonnet/MapperTest.java
+++ b/src/test/java/com/datasonnet/MapperTest.java
@@ -16,7 +16,7 @@ public class MapperTest {
     @ParameterizedTest
     @MethodSource("simpleProvider")
     void simple(String jsonnet, String json, String expected) {
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
         assertEquals(expected, mapper.transform(json));
     }
 
@@ -47,7 +47,7 @@ public class MapperTest {
     @Test
     void parseErrorLineNumber() {
         try {
-            Mapper mapper = new Mapper("function(payload) DS.time.now() a", new ArrayList<>(), false);
+            Mapper mapper = new Mapper("function(payload) DS.time.now() a", Collections.emptyList(), false);
             fail("Must fail to parse");
         } catch(IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Expected end-of-input at line 1 column 33"), "Found message: " + e.getMessage());
@@ -57,7 +57,7 @@ public class MapperTest {
     @Test
     void parseErrorLineNumberWhenWrapped() {
         try {
-            Mapper mapper = new Mapper("DS.time.now() a", new ArrayList<>(), true);
+            Mapper mapper = new Mapper("DS.time.now() a", Collections.emptyList(), true);
             fail("Must fail to parse");
         } catch(IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Expected end-of-input at line 1 column 15"), "Found message: " + e.getMessage());
@@ -67,7 +67,7 @@ public class MapperTest {
     @Test
     void noTopLevelFunction() {
         try {
-            Mapper mapper = new Mapper("{}", new ArrayList<>(), false);
+            Mapper mapper = new Mapper("{}", Collections.emptyList(), false);
             fail("Must fail to execute");
         } catch(IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Top Level Function"), "Found message: " + e.getMessage());
@@ -77,7 +77,7 @@ public class MapperTest {
     @Test
     void executeErrorLineNumber() {
         try {
-            Mapper mapper = new Mapper("function(payload) payload.foo", new ArrayList<>(), false);
+            Mapper mapper = new Mapper("function(payload) payload.foo", Collections.emptyList(), false);
             mapper.transform("{}");
             fail("Must fail to execute");
         } catch(IllegalArgumentException e) {
@@ -88,7 +88,7 @@ public class MapperTest {
     @Test
     void executeErrorLineNumberWhenWrapped() {
         try {
-            Mapper mapper = new Mapper("payload.foo", new ArrayList<>(), true);
+            Mapper mapper = new Mapper("payload.foo", Collections.emptyList(), true);
             mapper.transform("{}");
             fail("Must fail to execute");
         } catch(IllegalArgumentException e) {
@@ -98,7 +98,7 @@ public class MapperTest {
 
     @Test
     void includedJsonnetLibraryWorks() {
-        Mapper mapper = new Mapper("DS.Util.select({a: {b: 5}}, 'a.b')", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.Util.select({a: {b: 5}}, 'a.b')", Collections.emptyList(), true);
         assertEquals("5", mapper.transform("{}"));
     }
 
@@ -123,7 +123,7 @@ public class MapperTest {
     @Test
     void noTopLevelFunctionArgs() {
         try {
-            Mapper mapper = new Mapper("function() { test: \'HelloWorld\' } ", new ArrayList<>(), false);
+            Mapper mapper = new Mapper("function() { test: \'HelloWorld\' } ", Collections.emptyList(), false);
             fail("Must fail to execute");
         } catch(IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Top Level Function must have at least one argument"), "Found message: " + e.getMessage());

--- a/src/test/java/com/datasonnet/UtilLibraryTest.java
+++ b/src/test/java/com/datasonnet/UtilLibraryTest.java
@@ -3,8 +3,7 @@ package com.datasonnet;
 import com.datasonnet.util.TestResourceReader;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -14,18 +13,18 @@ public class UtilLibraryTest {
     void testDuplicates() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("utilLibDuplicatesTest.json");
 
-        Mapper mapper = new Mapper("DS.Util.duplicates(payload.primitive)", new ArrayList<>(), true);
-        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper("DS.Util.duplicates(payload.primitive)", Collections.emptyList(), true);
+        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").contents();
         assertEquals(mappedJson, "[\"hello\",\"world\"]");
 
 //TODO these won't work until sjsonnet supports key functions
 
-//        mapper = new Mapper("DS.Util.duplicates(payload.complex, function(x) x.language.name)", new ArrayList<>(), true);
-//        mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/json").contents();
+//        mapper = new Mapper("DS.Util.duplicates(payload.complex, function(x) x.language.name)", Collections.emptyList(), true);
+//        mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").contents();
 //        assertEquals(mappedJson, "[{\"language\":{\"name\":\"Java8\",\"version\":\"1.8.0\"}}]");
 //
-//        mapper = new Mapper("DS.Util.duplicates(payload.moreComplex, function(x) std.substr(x.language.version, 0, 3))", new ArrayList<>(), true);
-//        mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/json").contents();
+//        mapper = new Mapper("DS.Util.duplicates(payload.moreComplex, function(x) std.substr(x.language.version, 0, 3))", Collections.emptyList(), true);
+//        mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").contents();
 //        assertEquals(mappedJson, "[{\"language\":{\"name\":\"Java1.8\",\"version\":\"1.8_152\"}}]");
     }
 
@@ -38,8 +37,8 @@ public class UtilLibraryTest {
     @Test
     void testReverse() throws Exception {
         String jsonData = "[\"a\",\"b\",\"c\",\"d\"]";
-        Mapper mapper = new Mapper("DS.Util.reverse(payload)", new ArrayList<>(), true);
-        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper("DS.Util.reverse(payload)", Collections.emptyList(), true);
+        String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").contents();
 
         assertEquals(mappedJson, "[\"d\",\"c\",\"b\",\"a\"]");
     }
@@ -68,8 +67,8 @@ public class UtilLibraryTest {
     private void testDS(String dsFileName, String input) throws Exception {
         String ds = TestResourceReader.readFileAsString(dsFileName);
 
-        Mapper mapper = new Mapper(ds, new ArrayList<>(), true);
-        String mappedJson = mapper.transform(new StringDocument(input, "application/json"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper(ds, Collections.emptyList(), true);
+        String mappedJson = mapper.transform(new StringDocument(input, "application/json"), Collections.emptyMap(), "application/json").contents();
 
         assertEquals(mappedJson, "true");
     }

--- a/src/test/java/com/datasonnet/XMLPropertyTest.java
+++ b/src/test/java/com/datasonnet/XMLPropertyTest.java
@@ -19,8 +19,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -32,8 +31,8 @@ public class XMLPropertyTest {
     @Property
     public void reversible(@From(XMLGenerator.class) @Dictionary("xml.dict") Document dom) throws Exception {
         String xml = XMLDocumentUtils.documentToString(dom);
-        Mapper mapper = new Mapper("DS.Formats.write(DS.Formats.read(payload, \"application/xml\"), \"application/xml\")", new ArrayList<>(), true);
-        com.datasonnet.Document output = mapper.transform(new StringDocument(xml, "application/xml"), new HashMap<>(), "application/xml");
+        Mapper mapper = new Mapper("DS.Formats.write(DS.Formats.read(payload, \"application/xml\"), \"application/xml\")", Collections.emptyList(), true);
+        com.datasonnet.Document output = mapper.transform(new StringDocument(xml, "application/xml"), Collections.emptyMap(), "application/xml");
         DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document parsed = db.parse(new ByteArrayInputStream(output.contents().getBytes("UTF-8")));
         assertTrue("For input " + xml + " found output " + output.contents(), dom.isEqualNode(parsed));

--- a/src/test/java/com/datasonnet/XMLReaderTest.java
+++ b/src/test/java/com/datasonnet/XMLReaderTest.java
@@ -9,8 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 public class XMLReaderTest {
 
@@ -28,8 +27,8 @@ public class XMLReaderTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
-        String mapped = mapper.transform(new StringDocument(xml, "application/xml"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        String mapped = mapper.transform(new StringDocument(xml, "application/xml"), Collections.emptyMap(), "application/json").contents();
 
         // the b namespace must have been remapped
         assertThat(mapped, not(containsString("b:b")));
@@ -50,8 +49,8 @@ public class XMLReaderTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
-        String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), Collections.emptyMap(), "application/json").contents();
 
         JSONAssert.assertEquals(expectedJson, mappedJson, false);
     }
@@ -77,8 +76,8 @@ public class XMLReaderTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper("DS.Formats.read(payload, \"application/xml\")", new ArrayList<>(), true);
-        String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), new HashMap<>(), "application/json").contents();
+        Mapper mapper = new Mapper("DS.Formats.read(payload, \"application/xml\")", Collections.emptyList(), true);
+        String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), Collections.emptyMap(), "application/json").contents();
 
         JSONAssert.assertEquals(expectedJson, mappedJson, false);
     }

--- a/src/test/java/com/datasonnet/XMLWriterTest.java
+++ b/src/test/java/com/datasonnet/XMLWriterTest.java
@@ -6,7 +6,7 @@ import com.datasonnet.Mapper;
 import org.junit.jupiter.api.Test;
 import org.xmlunit.matchers.CompareMatcher;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,8 +25,8 @@ public class XMLWriterTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
-        String mapped = mapper.transform(new StringDocument(json, "application/json"), new HashMap<>(), "application/xml").contents();
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        String mapped = mapper.transform(new StringDocument(json, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         // original mapping is gone
         assertThat(mapped, not(containsString("b:a")));
@@ -48,8 +48,8 @@ public class XMLWriterTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
-        String mapped = mapper.transform(new StringDocument(json, "application/json"), new HashMap<>(), "application/xml").contents();
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        String mapped = mapper.transform(new StringDocument(json, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         // original mapping is gone
         assertThat(mapped, not(containsString("b:a")));
@@ -71,8 +71,8 @@ public class XMLWriterTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper(jsonnet, new ArrayList<>(), true);
-        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         Map<String, String> namespaces = new HashMap<>();
         namespaces.put("test", "http://www.modusbox.com");
@@ -88,13 +88,13 @@ public class XMLWriterTest {
 
 //        Mapper mapper = new Mapper("local params = {\n" +
 //                "    \"XmlVersion\" : \"1.1\"\n" +
-//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", new ArrayList<>(), true);
+//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", Collections.emptyList(), true);
         DataFormatService.getInstance().findAndRegisterPlugins();
 
         Mapper mapper = new Mapper("local params = {\n" +
                 "    \"XmlVersion\" : \"1.1\"\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", new ArrayList<>(), true);
-        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
+        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertEquals(expectedXml, mappedXml);
 
@@ -109,13 +109,13 @@ public class XMLWriterTest {
 
 //        Mapper mapper = new Mapper("local params = {\n" +
 //                "    \"XmlVersion\" : \"1.1\"\n" +
-//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", new ArrayList<>(), true);
+//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", Collections.emptyList(), true);
         DataFormatService.getInstance().findAndRegisterPlugins();
 
         Mapper mapper = new Mapper("local params = {\n" +
                 "    \"XmlVersion\" : \"1.1\"\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", new ArrayList<>(), true);
-        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
+        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
     }
@@ -127,13 +127,13 @@ public class XMLWriterTest {
 
 //        Mapper mapper = new Mapper("local params = {\n" +
 //                "    \"XmlVersion\" : \"1.1\"\n" +
-//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", new ArrayList<>(), true);
+//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", Collections.emptyList(), true);
         DataFormatService.getInstance().findAndRegisterPlugins();
 
         Mapper mapper = new Mapper("local params = {\n" +
                 "    \"XmlVersion\" : \"1.1\"\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", new ArrayList<>(), true);
-        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
+        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
     }
@@ -146,14 +146,14 @@ public class XMLWriterTest {
 //        Mapper mapper = new Mapper("local params = {\n" +
 //                "    \"AutoEmptyElements\" : true,\n" +
 //                "    \"NullAsEmptyElement\" : true\n" +
-//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", new ArrayList<>(), true);
+//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", Collections.emptyList(), true);
         DataFormatService.getInstance().findAndRegisterPlugins();
 
         Mapper mapper = new Mapper("local params = {\n" +
                 "    \"AutoEmptyElements\" : true,\n" +
                 "    \"NullAsEmptyElement\" : true\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", new ArrayList<>(), true);
-        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
+        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
 
@@ -162,12 +162,12 @@ public class XMLWriterTest {
 //        mapper = new Mapper("local params = {\n" +
 //                "    \"AutoEmptyElements\" : true,\n" +
 //                "    \"NullAsEmptyElement\" : false\n" +
-//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", new ArrayList<>(), true);
+//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", Collections.emptyList(), true);
         mapper = new Mapper("local params = {\n" +
                 "    \"AutoEmptyElements\" : true,\n" +
                 "    \"NullAsEmptyElement\" : false\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", new ArrayList<>(), true);
-        mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
+        mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
     }
@@ -178,24 +178,24 @@ public class XMLWriterTest {
 
 //        Mapper mapper = new Mapper("local params = {\n" +
 //                "    \"OmitXmlDeclaration\" : true\n" +
-//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", new ArrayList<>(), true);
+//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", Collections.emptyList(), true);
         DataFormatService.getInstance().findAndRegisterPlugins();
 
         Mapper mapper = new Mapper("local params = {\n" +
                 "    \"OmitXmlDeclaration\" : true\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", new ArrayList<>(), true);
-        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
+        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertFalse(mappedXml.contains("<?xml"));
 
 //        mapper = new Mapper("local params = {\n" +
 //                "    \"OmitXmlDeclaration\" : false\n" +
-//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", new ArrayList<>(), true);
+//                "};DS.Formats.writeExt(payload, \"application/xml\", params)", Collections.emptyList(), true);
         mapper = new Mapper("local params = {\n" +
                 "    \"OmitXmlDeclaration\" : false\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", new ArrayList<>(), true);
+                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
 
-        mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+        mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertTrue(mappedXml.startsWith("<?xml"));
     }
@@ -205,8 +205,8 @@ public class XMLWriterTest {
 
         DataFormatService.getInstance().findAndRegisterPlugins();
 
-        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")", new ArrayList<>(), true);
-        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), new HashMap<>(), "application/xml").contents();
+        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")", Collections.emptyList(), true);
+        String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").contents();
 
         assertTrue(mappedXml.contains("<?xml"));
     }

--- a/src/test/java/com/datasonnet/ZonedDateTimeTest.java
+++ b/src/test/java/com/datasonnet/ZonedDateTimeTest.java
@@ -4,8 +4,7 @@ import com.datasonnet.Mapper;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,7 +12,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testOffset() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.offset(\"2019-07-22T21:00:00Z\", \"P1Y1D\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.offset(\"2019-07-22T21:00:00Z\", \"P1Y1D\")", Collections.emptyList(), true);
         String offsetDate = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("2020-07-23T21:00:00Z".equals(offsetDate));
 //        System.out.println("Offset date is " + offsetDate);
@@ -23,7 +22,7 @@ public class ZonedDateTimeTest {
     void testNow() {
         Instant before = Instant.now();
 
-        Mapper mapper = new Mapper("DS.ZonedDateTime.now()", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.now()", Collections.emptyList(), true);
         // getting rid of quotes so the Instant parser works
         Instant mapped = Instant.parse(mapper.transform("{}").replaceAll("\"", ""));
 
@@ -35,7 +34,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testFormat() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.format(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"d MMM uuuu\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.format(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"d MMM uuuu\")", Collections.emptyList(), true);
         String formattedDate = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("4 Jul 2019".equals(formattedDate));
@@ -43,7 +42,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testCompare() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.compare(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.compare(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\")", Collections.emptyList(), true);
         String compareResult = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("0".equals(compareResult));
@@ -51,7 +50,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testTimezone() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.changeTimeZone(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\", \"America/Los_Angeles\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.changeTimeZone(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\", \"America/Los_Angeles\")", Collections.emptyList(), true);
         String newTimezone = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("New date is " + newTimezone);
         assertTrue("2019-07-04T19:00:00-0700".equals(newTimezone));
@@ -59,11 +58,11 @@ public class ZonedDateTimeTest {
 
     @Test
     void testLocalDT() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.toLocalDate(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")", new ArrayList<>(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.toLocalDate(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")", Collections.emptyList(), true);
         String newDate = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("2019-07-04".equals(newDate));
 
-        mapper = new Mapper("DS.ZonedDateTime.toLocalTime(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")", new ArrayList<>(), true);
+        mapper = new Mapper("DS.ZonedDateTime.toLocalTime(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")", Collections.emptyList(), true);
         String newTime = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("21:00:00".equals(newTime));
 


### PR DESCRIPTION
Hey guys, while going through the project as whole to grok what's going on I found a couple changes that I thought might be of use.

1. Changing the `new ArrayList` and `new HashMap` instantiations that don't get any values, to use `Collections.empty()` instead. This should be marginally more performant and also idiomatic I think.

2. Removing the copied functions from the `sjsonnet.Std` class. The `builtin0` method seems like the one that accommodates many arguments through what seems like a varargs signature (not a scala expert). So we can use it as an array to get the args we need for those functions that need more than 4 args, instead of manually crafting new methods and duplicating code from sjsonnet.

Let me know if this makes sense or not. 