### PR TITLE
make data format service per-mapper, and proxy methods on the mapper

### DIFF
--- a/src/main/java/com/datasonnet/commands/Run.java
+++ b/src/main/java/com/datasonnet/commands/Run.java
@@ -43,14 +43,14 @@ public class Run implements Callable<Void> {
     List<File> importFiles = new ArrayList<>();
 
     @CommandLine.Option(names = {"-n", "--no-wrap"}, description = "Do not wrap in a function call. Only use this if your transformation is already a top-level function.")
-    boolean alreadyWrapped;
+    boolean alreadyWrapped = false;
 
     @CommandLine.Option(names = {"-o", "--output-type"}, description = "Handle the output as this format. Defaults to JSON.")
     String outputType = "application/json";
 
     @Override
     public Void call() throws Exception {
-        Mapper mapper = new Mapper(Main.readFile(datasonnet), combinedArguments().keySet(), imports(), !alreadyWrapped);
+        Mapper mapper = new Mapper(Main.readFile(datasonnet), combinedArguments().keySet(), imports(), !alreadyWrapped, true);
         Document result = mapper.transform(new StringDocument(payload(), suffix(datasonnet)), combinedArguments(), outputType);
         String contents = result.getContentsAsString();
         System.out.println(contents);

--- a/src/main/java/com/datasonnet/spi/DataFormatService.java
+++ b/src/main/java/com/datasonnet/spi/DataFormatService.java
@@ -9,19 +9,10 @@ import java.util.*;
 
 public class DataFormatService {
 
-    private static DataFormatService service;
-
     private Map<String, List<DataFormatPlugin>> pluginRegistry = new HashMap<>();
 
-    DataFormatService() {
+    public DataFormatService() {
         registerPlugin(new JSONFormatPlugin());
-    }
-
-    public static synchronized DataFormatService getInstance() {
-        if (service == null) {
-            service = new DataFormatService();
-        }
-        return service;
     }
 
     public void registerPlugin(DataFormatPlugin plugin) {
@@ -63,12 +54,7 @@ public class DataFormatService {
         }};
     }
 
-    public List<String> getSupportedIdentifiers() {
-        return new ArrayList(pluginRegistry.keySet());
-    }
-
     public void findAndRegisterPlugins() {
         registerPlugins(findPlugins());
     }
-    
 }

--- a/src/main/scala/com/datasonnet/DS.scala
+++ b/src/main/scala/com/datasonnet/DS.scala
@@ -17,7 +17,7 @@ import ujson.Value
 
 object DS {
 
-  val libraries:  Map[String, Val] = Map(
+  def libraries(dataFormats: DataFormatService):  Map[String, Val] = Map(
     "ZonedDateTime" -> library(
       builtin0("now") { (vals, ev, fs) => Instant.now().toString() },
 
@@ -83,7 +83,7 @@ object DS {
         } else {
           args("params").cast[Val.Obj]
         }
-        read(data, mimeType, params, ev)
+        read(dataFormats, data, mimeType, params, ev)
       },
       builtinWithDefaults("write",
         "data" -> None,
@@ -96,7 +96,7 @@ object DS {
         } else {
           args("params").cast[Val.Obj]
         }
-        write(data, mimeType, params, ev)
+        write(dataFormats, data, mimeType, params, ev)
       },
 
     ),
@@ -208,8 +208,8 @@ object DS {
 
   )
 
-  def read(data: String, mimeType: String, params: Val.Obj, ev: EvalScope): Val = {
-    val plugin = DataFormatService.getInstance().getPluginFor(mimeType)
+  def read(dataFormats: DataFormatService, data: String, mimeType: String, params: Val.Obj, ev: EvalScope): Val = {
+    val plugin = dataFormats.getPluginFor(mimeType)
     if (plugin == null) {
       throw new Error.Delegate("No suitable plugin found for mime type: " + mimeType)
     }
@@ -225,8 +225,8 @@ object DS {
     Materializer.reverse(json)
   }
 
-  def write(json: Val, mimeType: String, params: Val.Obj, ev: EvalScope): String = {
-    val plugin = DataFormatService.getInstance().getPluginFor(mimeType)
+  def write(dataFormats: DataFormatService, json: Val, mimeType: String, params: Val.Obj, ev: EvalScope): String = {
+    val plugin = dataFormats.getPluginFor(mimeType)
     if (plugin == null) {
       throw new Error.Delegate("No suitable plugin found for mime type: " + mimeType);
     }

--- a/src/main/scala/com/datasonnet/Mapper.scala
+++ b/src/main/scala/com/datasonnet/Mapper.scala
@@ -144,7 +144,7 @@ object Mapper {
   }
 }
 
-class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imports: java.util.Map[String, String], needsWrapper: Boolean) {
+class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imports: java.util.Map[String, String], needsWrapper: Boolean, autoRegisterDataFormats: Boolean) {
 
   var header = Header.parseHeader(jsonnet);
 
@@ -154,9 +154,15 @@ class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imp
 
   def lineOffset = if (needsWrapper) 1 else 0
 
-  def this(jsonnet: String, argumentNames: java.lang.Iterable[String], needsWrapper: Boolean) {
-    this(jsonnet, argumentNames, Collections.emptyMap(), needsWrapper)
+  def this(jsonnet: String, argumentNames: java.lang.Iterable[String], needsWrapper: Boolean, autoRegisterDataFormats: Boolean) {
+    this(jsonnet, argumentNames, Collections.emptyMap(), needsWrapper, autoRegisterDataFormats)
   }
+
+  def this(jsonnet: String, argumentNames: java.lang.Iterable[String], needsWrapper: Boolean) {
+    this(jsonnet, argumentNames, Collections.emptyMap(), needsWrapper, true)
+  }
+
+  def this(jsonnet: String) = this(jsonnet, Collections.emptyList(), Collections.emptyMap(), true, true)
 
   private def importer(parent: Path, path: String): Option[(Path, String)] = for {
     resolved <- parent match {
@@ -178,6 +184,10 @@ class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imp
   val evaluator = new NoFileEvaluator(jsonnet, DataSonnetPath("."), parseCache, importer, header.isPreserveOrder)
 
   val dataFormats = new DataFormatService()
+
+  if (autoRegisterDataFormats) {
+    dataFormats.findAndRegisterPlugins()
+  }
 
   def registerPlugin(plugin: DataFormatPlugin[_]) = dataFormats.registerPlugin(plugin)
 

--- a/src/main/scala/com/datasonnet/Mapper.scala
+++ b/src/main/scala/com/datasonnet/Mapper.scala
@@ -94,8 +94,8 @@ object Mapper {
     case _ => false
   }).getOrElse(throw new UnsupportedOperationException("Illegal Data Format Plugin: Must Only Take String or Object"))
 
-  def input(name: String, data: Document, header: Header): Expr = {
-    val plugin = DataFormatService.getInstance().getPluginFor(data.getMimeType)
+  def input(dataFormats: DataFormatService, name: String, data: Document, header: Header): Expr = {
+    val plugin = dataFormats.getPluginFor(data.getMimeType)
     if (plugin != null) {
       val params = header.getInputParameters(name, data.getMimeType)
       checkParams(params, plugin.getReadParameters(), plugin.getPluginId)
@@ -122,8 +122,8 @@ object Mapper {
     }
   }
 
-  def output(output: ujson.Value, mimeType: String, header: Header): Document = {
-    val plugin = DataFormatService.getInstance().getPluginFor(mimeType)
+  def output(dataFormats: DataFormatService, output: ujson.Value, mimeType: String, header: Header): Document = {
+    val plugin = dataFormats.getPluginFor(mimeType)
     if (plugin != null) {
       val params = header.getOutputParameters(mimeType)
       checkParams(params, plugin.getWriteParameters(), plugin.getPluginId)
@@ -158,7 +158,7 @@ class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imp
     this(jsonnet, argumentNames, Collections.emptyMap(), needsWrapper)
   }
 
-  def importer(parent: Path, path: String): Option[(Path, String)] = for {
+  private def importer(parent: Path, path: String): Option[(Path, String)] = for {
     resolved <- parent match {
       case DataSonnetPath("") => Some(path)
       case DataSonnetPath(p) => Some(p + "/" + path)
@@ -172,13 +172,30 @@ class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imp
     combined = (DataSonnetPath(resolved) -> contents)
   } yield combined
 
+
   private val parseCache = collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]]()
 
   val evaluator = new NoFileEvaluator(jsonnet, DataSonnetPath("."), parseCache, importer, header.isPreserveOrder)
 
-  private val libraries:  Map[String, Val] = Map(
+  val dataFormats = new DataFormatService()
+
+  def registerPlugin(plugin: DataFormatPlugin[_]) = dataFormats.registerPlugin(plugin)
+
+  def registerPluginFor(identifier: String, plugin: DataFormatPlugin[_]) =
+    dataFormats.registerPluginFor(identifier, plugin)
+
+  def registerPlugins(plugins: java.lang.Iterable[DataFormatPlugin[_]]) =
+    dataFormats.registerPlugins(plugins)
+
+  def getPluginFor(identifier: String) = dataFormats.getPluginFor(identifier)
+
+  def findPlugins = dataFormats.findPlugins()
+
+  def findAndRegisterPlugins() = dataFormats.findAndRegisterPlugins()
+
+  private val libraries = Map(
     "DS" -> Mapper.objectify(
-      DS.libraries + Mapper.library(evaluator, "Util", parseCache)
+      DS.libraries(dataFormats) + Mapper.library(evaluator, "Util", parseCache)
     )
   )
 
@@ -225,10 +242,12 @@ class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imp
     // okay, okay, so at this point we: 1) figure out if we can get an object or a string
     // then 2) we see if the converter we get for the mime type is compatible...
     // hrmmm, any reason we can't filter by type? Whatevfer, that's internal, don't worry about it
-    val data = Mapper.input("payload", payload, header)
+    val data = Mapper.input(dataFormats, "payload", payload, header)
 
     //val parsedArguments = arguments.asScala.view.mapValues { Mapper.input(_, header) }
-    val parsedArguments = arguments.asScala.view.toMap[String, Document].map { case (name, data) => (name, Mapper.input(name, data, header)) }
+    val parsedArguments = arguments.asScala.view.toMap[String, Document].map {
+      case (name, data) => (name, Mapper.input(dataFormats, name, data, header))
+    }
 
     val first +: rest = function.params.args
 
@@ -251,6 +270,6 @@ class Mapper(var jsonnet: String, argumentNames: java.lang.Iterable[String], imp
         throw new IllegalArgumentException("Problem executing map: " + Mapper.expandErrorLineNumber(s.toString, lineOffset).replace("\t", "    "))
     }
 
-    Mapper.output(materialized, outputMimeType, header)
+    Mapper.output(dataFormats, materialized, outputMimeType, header)
   }
 }

--- a/src/test/java/com/datasonnet/CSVReaderTest.java
+++ b/src/test/java/com/datasonnet/CSVReaderTest.java
@@ -15,11 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CSVReaderTest {
 
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
-
     @Test
     void testCSVReader() throws URISyntaxException, IOException {
         Document data = new StringDocument(
@@ -28,6 +23,8 @@ public class CSVReaderTest {
         );
 
         Mapper mapper = new Mapper("{ fName: payload[0][\"First Name\"] }", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         Document mapped = mapper.transform(data, Collections.emptyMap(), "application/json");
 
         assertEquals("{\"fName\":\"Eugene\"}", mapped.getContentsAsString());
@@ -42,6 +39,8 @@ public class CSVReaderTest {
         String jsonnet = TestResourceReader.readFileAsString("readCSVExtTest.ds");
 
         Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         Document mapped = mapper.transform(data, Collections.emptyMap(), "application/json");
 
         assertEquals("{\"fName\":\"Eugene\",\"num\":\"234\"}", mapped.getContentsAsString());

--- a/src/test/java/com/datasonnet/CSVReaderTest.java
+++ b/src/test/java/com/datasonnet/CSVReaderTest.java
@@ -22,8 +22,8 @@ public class CSVReaderTest {
                 "application/csv"
         );
 
-        Mapper mapper = new Mapper("{ fName: payload[0][\"First Name\"] }", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper("{ fName: payload[0][\"First Name\"] }");
+
 
         Document mapped = mapper.transform(data, Collections.emptyMap(), "application/json");
 
@@ -38,8 +38,8 @@ public class CSVReaderTest {
         );
         String jsonnet = TestResourceReader.readFileAsString("readCSVExtTest.ds");
 
-        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(jsonnet);
+
 
         Document mapped = mapper.transform(data, Collections.emptyMap(), "application/json");
 

--- a/src/test/java/com/datasonnet/CSVWriterTest.java
+++ b/src/test/java/com/datasonnet/CSVWriterTest.java
@@ -15,11 +15,6 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CSVWriterTest {
-
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
     
     @Test
     void testCSVWriter() throws URISyntaxException, IOException {
@@ -30,6 +25,8 @@ public class CSVWriterTest {
         );
 
         Mapper mapper = new Mapper("payload", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/csv").getContentsAsString();
         String expected = TestResourceReader.readFileAsString("writeCSVTest.csv");
         assertEquals(expected.trim(), mapped.trim());
@@ -44,6 +41,8 @@ public class CSVWriterTest {
         String datasonnet = TestResourceReader.readFileAsString("writeCSVExtTest.ds");
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/csv").getContentsAsString();
         String expected = TestResourceReader.readFileAsString("writeCSVExtTest.csv");
         assertEquals(expected.trim(), mapped.trim());
@@ -58,6 +57,8 @@ public class CSVWriterTest {
         );
 
         Mapper mapper = new Mapper("{ embeddedCSVValue: DS.Formats.write(payload, \"application/csv\") }", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/json").getContentsAsString();
         String expected = "{\"embeddedCSVValue\":\"\\\"First Name\\\",\\\"Last Name\\\",Phone\\nWilliam,Shakespeare,\\\"(123)456-7890\\\"\\nChristopher,Marlow,\\\"(987)654-3210\\\"\\n\"}";
         assertEquals(expected.trim(), mapped.trim());
@@ -72,6 +73,8 @@ public class CSVWriterTest {
         String datasonnet = TestResourceReader.readFileAsString("writeCSVFunctionExtTest.ds");
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/json").getContentsAsString();
         String expected = "{\"embeddedCSVValue\":\"'William'|'Shakespeare'|'(123)456-7890'\\n'Christopher'|'Marlow'|'(987)654-3210'\\n\"}";
         assertEquals(expected.trim(), mapped.trim());

--- a/src/test/java/com/datasonnet/CSVWriterTest.java
+++ b/src/test/java/com/datasonnet/CSVWriterTest.java
@@ -24,8 +24,8 @@ public class CSVWriterTest {
                 "application/json"
         );
 
-        Mapper mapper = new Mapper("payload", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper("payload");
+
 
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/csv").getContentsAsString();
         String expected = TestResourceReader.readFileAsString("writeCSVTest.csv");
@@ -40,8 +40,8 @@ public class CSVWriterTest {
         );
         String datasonnet = TestResourceReader.readFileAsString("writeCSVExtTest.ds");
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
+
 
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/csv").getContentsAsString();
         String expected = TestResourceReader.readFileAsString("writeCSVExtTest.csv");
@@ -56,8 +56,8 @@ public class CSVWriterTest {
                 "application/json"
         );
 
-        Mapper mapper = new Mapper("{ embeddedCSVValue: DS.Formats.write(payload, \"application/csv\") }", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper("{ embeddedCSVValue: DS.Formats.write(payload, \"application/csv\") }");
+
 
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/json").getContentsAsString();
         String expected = "{\"embeddedCSVValue\":\"\\\"First Name\\\",\\\"Last Name\\\",Phone\\nWilliam,Shakespeare,\\\"(123)456-7890\\\"\\nChristopher,Marlow,\\\"(987)654-3210\\\"\\n\"}";
@@ -72,8 +72,8 @@ public class CSVWriterTest {
         );
         String datasonnet = TestResourceReader.readFileAsString("writeCSVFunctionExtTest.ds");
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
+
 
         String mapped = mapper.transform(data, Collections.emptyMap(), "application/json").getContentsAsString();
         String expected = "{\"embeddedCSVValue\":\"'William'|'Shakespeare'|'(123)456-7890'\\n'Christopher'|'Marlow'|'(987)654-3210'\\n\"}";

--- a/src/test/java/com/datasonnet/CryptoTest.java
+++ b/src/test/java/com/datasonnet/CryptoTest.java
@@ -12,32 +12,32 @@ public class CryptoTest {
 
     @Test
     void testHash() {
-        Mapper mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD2\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD2\")");
         String hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("4227ce10dca49dd2d0ba3f438d1ea9f3".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD5\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"MD5\")");
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("68e109f0f40ca72a15e05cc22786f8e6".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-1\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-1\")");
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("db8ac1c259eb89d4a131b253bacfca5f319d54f2".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-256\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-256\")");
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-384\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-384\")");
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("293cd96eb25228a6fb09bfa86b9148ab69940e68903cbc0527a4fb150eec1ebe0f1ffce0bc5e3df312377e0a68f1950a".equals(hash));
 
-        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-512\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"SHA-512\")");
         hash = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("8ae6ae71a75d3fb2e0225deeb004faf95d816a0a58093eb4cb5a3aa0f197050d7a4dc0a2d5c6fbae5fb5b0d536a0a9e6b686369fa57a027687c3630321547596".equals(hash));
 
         try {
-            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")", Collections.emptyList(), true);
+            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")");
             hash = mapper.transform("{}").replaceAll("\"", "");
             fail("This should fail with NoSuchAlgorithmException");
         } catch (Exception e) {
@@ -48,20 +48,20 @@ public class CryptoTest {
 
     @Test
     void testHMAC() {
-        Mapper mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA1\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA1\")");
         String hmac = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("91f27e2a84a9804b101257a2edfd121b02917e1a".equals(hmac));
 
-        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA256\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA256\")");
         hmac = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("7854220ef827b07529509f68f391a80bf87fff328dbda140ed582520a1372dc1".equals(hmac));
 
-        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA512\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.hmac(\"HelloWorld\", \"PortX rules!\", \"HmacSHA512\")");
         hmac = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("0acbc9c5d0828f3bc9c30e311311073089f969d7ccbfacc457c8da289bc163fee911f75b3b018b2d0c7a09e758b970fcdc6b6488118fd52dbbf31b9ee0415d4c".equals(hmac));
 
         try {
-            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")", Collections.emptyList(), true);
+            mapper = new Mapper("DS.Crypto.hash(\"HelloWorld\", \"DUMMY\")");
             hmac = mapper.transform("{}").replaceAll("\"", "");
             fail("This should fail with NoSuchAlgorithmException");
         } catch (Exception e) {
@@ -72,11 +72,11 @@ public class CryptoTest {
 
     @Test
     void testEncrypt() {
-        Mapper mapper = new Mapper("DS.Crypto.encrypt(\"HelloWorld\", \"DataSonnet123\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.Crypto.encrypt(\"HelloWorld\", \"DataSonnet123\")");
         String encrypted = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("HdK8opktKiK3ero0RJiYbA==".equals(encrypted));
 
-        mapper = new Mapper("DS.Crypto.decrypt(\"HdK8opktKiK3ero0RJiYbA==\", \"DataSonnet123\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Crypto.decrypt(\"HdK8opktKiK3ero0RJiYbA==\", \"DataSonnet123\")");
         String decrypted = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("HelloWorld".equals(decrypted));
     }

--- a/src/test/java/com/datasonnet/HeaderTest.java
+++ b/src/test/java/com/datasonnet/HeaderTest.java
@@ -14,11 +14,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class HeaderTest {
 
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
-
     @Test
     void testHeader() throws Exception {
         Document payload = new StringDocument(
@@ -34,6 +29,8 @@ public class HeaderTest {
         Map<String, Document> variables = Collections.singletonMap("myVar", myVar);
 
         Mapper mapper = new Mapper(ds, variables.keySet(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(payload, variables, "application/csv").getContentsAsString();
 
         assertTrue(mapped.startsWith("\"greetings\"|\"name\""));
@@ -49,6 +46,8 @@ public class HeaderTest {
         String ds = TestResourceReader.readFileAsString("dotMimeTypeTest.ds");
 
         Mapper mapper = new Mapper(ds, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(payload, Collections.emptyMap(), "text/plain").getContentsAsString();
         assertEquals("HelloWorld", mapped);
         mapped = mapper.transform(payload, Collections.emptyMap(), "application/test.test").getContentsAsString();
@@ -64,6 +63,7 @@ public class HeaderTest {
         String ds = TestResourceReader.readFileAsString("illegalParameter.ds");
 
         Mapper mapper = new Mapper(ds, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
 
         try {
             String mapped = mapper.transform(payload, Collections.emptyMap(), "text/plain").getContentsAsString();

--- a/src/test/java/com/datasonnet/HeaderTest.java
+++ b/src/test/java/com/datasonnet/HeaderTest.java
@@ -29,7 +29,7 @@ public class HeaderTest {
         Map<String, Document> variables = Collections.singletonMap("myVar", myVar);
 
         Mapper mapper = new Mapper(ds, variables.keySet(), true);
-        mapper.findAndRegisterPlugins();
+
 
         String mapped = mapper.transform(payload, variables, "application/csv").getContentsAsString();
 
@@ -45,8 +45,8 @@ public class HeaderTest {
         );
         String ds = TestResourceReader.readFileAsString("dotMimeTypeTest.ds");
 
-        Mapper mapper = new Mapper(ds, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(ds);
+
 
         String mapped = mapper.transform(payload, Collections.emptyMap(), "text/plain").getContentsAsString();
         assertEquals("HelloWorld", mapped);
@@ -62,8 +62,8 @@ public class HeaderTest {
         );
         String ds = TestResourceReader.readFileAsString("illegalParameter.ds");
 
-        Mapper mapper = new Mapper(ds, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(ds);
+
 
         try {
             String mapped = mapper.transform(payload, Collections.emptyMap(), "text/plain").getContentsAsString();

--- a/src/test/java/com/datasonnet/ImportTest.java
+++ b/src/test/java/com/datasonnet/ImportTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ImportTest {
     @Test
     void simpleImport() {
-        Mapper mapper = new Mapper("import 'output.json'", Collections.emptyList(), Collections.singletonMap("output.json", "{\"a\": 5}"),true);
+        Mapper mapper = new Mapper("import 'output.json'", Collections.emptyList(), Collections.singletonMap("output.json", "{\"a\": 5}"),true, true);
         String result = mapper.transform("{}");
         assertEquals("{\"a\":5}", result);
     }
@@ -22,7 +22,7 @@ public class ImportTest {
     void importParseErrorLineNumber() {
         try {
             Mapper mapper = new Mapper("import 'output.json'", Collections.emptyList(),
-                    Collections.singletonMap("output.json", "a b"), true);
+                    Collections.singletonMap("output.json", "a b"), true, true);
             String result = mapper.transform("{}");
             fail("Import should fail");
         } catch(IllegalArgumentException e) {
@@ -34,7 +34,7 @@ public class ImportTest {
     void importExecuteErrorLineNumber() {
         try {
             Mapper mapper = new Mapper("import 'output.json'", Collections.emptyList(),
-                    Collections.singletonMap("output.json", "a.b"), true);
+                    Collections.singletonMap("output.json", "a.b"), true, true);
             String result = mapper.transform("{}");
             fail("Import should fail");
         } catch(IllegalArgumentException e) {
@@ -51,7 +51,7 @@ public class ImportTest {
             Mapper mapper = new Mapper("local testlib = import 'importTest.libsonnet'; local teststr = import 'importLibsonnetTest.json'; { greeting: testlib.sayHello('World') }", Collections.emptyList(), new HashMap<String, String>() {{
                 put("importTest.libsonnet", lib);
                 put("importLibsonnetTest.json", json);
-            }}, true);
+            }}, true, true);
         } catch (IllegalArgumentException e) {
             fail("This test should not fail, only libraries are evaluated at this point");
         }
@@ -62,7 +62,7 @@ public class ImportTest {
         try {
             final String libErr = TestResourceReader.readFileAsString("importTestFail.libsonnet");
             Mapper mapper = new Mapper("local testlib = import 'importTestFail.libsonnet'; { greeting: testlib.sayHello('World') }",
-                    Collections.emptyList(), Collections.singletonMap("importTestFail.libsonnet", libErr), true);
+                    Collections.emptyList(), Collections.singletonMap("importTestFail.libsonnet", libErr), true, true);
             fail("This test should fail");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Unable to parse library: importTestFail.libsonnet"), "Found message: " + e.getMessage());

--- a/src/test/java/com/datasonnet/JavaReaderTest.java
+++ b/src/test/java/com/datasonnet/JavaReaderTest.java
@@ -39,8 +39,8 @@ public class JavaReaderTest {
 
         String mapping = TestResourceReader.readFileAsString("readJavaTest.ds");
 
-        Mapper mapper = new Mapper(mapping, new ArrayList<>(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(mapping);
+
 
         String mapped = mapper.transform(data, new HashMap<>(), "application/json").getContentsAsString();
 

--- a/src/test/java/com/datasonnet/JavaReaderTest.java
+++ b/src/test/java/com/datasonnet/JavaReaderTest.java
@@ -18,10 +18,6 @@ import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JavaReaderTest {
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
 
     @Test
     void testJavaReader() throws Exception {
@@ -44,6 +40,8 @@ public class JavaReaderTest {
         String mapping = TestResourceReader.readFileAsString("readJavaTest.ds");
 
         Mapper mapper = new Mapper(mapping, new ArrayList<>(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(data, new HashMap<>(), "application/json").getContentsAsString();
 
         String expectedJson = TestResourceReader.readFileAsString("javaTest.json");

--- a/src/test/java/com/datasonnet/JavaWriterTest.java
+++ b/src/test/java/com/datasonnet/JavaWriterTest.java
@@ -30,8 +30,8 @@ public class JavaWriterTest {
 
         Document data = new StringDocument(json, "application/json");
 
-        Mapper mapper = new Mapper(mapping, new ArrayList<>(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(mapping);
+
 
         Document mapped = mapper.transform(data, new HashMap<>(), "application/java");
 
@@ -52,8 +52,8 @@ public class JavaWriterTest {
         //Test with default output, i.e. java.util.HashMap
         mapping = mapping.substring(mapping.lastIndexOf("*/") + 2);
 
-        mapper = new Mapper(mapping, new ArrayList<>(), true);
-        mapper.findAndRegisterPlugins();
+        mapper = new Mapper(mapping);
+
 
         mapped = mapper.transform(data, new HashMap<>(), "application/java");
 
@@ -74,8 +74,8 @@ public class JavaWriterTest {
 
         //Test calling write() function
         String mapping = TestResourceReader.readFileAsString("writeJavaFunctionTest.ds");
-        Mapper mapper = new Mapper(mapping, new ArrayList<>(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(mapping);
+
 
         try {
             mapper.transform(data, new HashMap<>(), "application/java");

--- a/src/test/java/com/datasonnet/JavaWriterTest.java
+++ b/src/test/java/com/datasonnet/JavaWriterTest.java
@@ -21,10 +21,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class JavaWriterTest {
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
 
     @Test
     void testJavaWriter() throws Exception {
@@ -35,6 +31,8 @@ public class JavaWriterTest {
         Document data = new StringDocument(json, "application/json");
 
         Mapper mapper = new Mapper(mapping, new ArrayList<>(), true);
+        mapper.findAndRegisterPlugins();
+
         Document mapped = mapper.transform(data, new HashMap<>(), "application/java");
 
         Object result = mapped.getContentsAsObject();
@@ -55,6 +53,8 @@ public class JavaWriterTest {
         mapping = mapping.substring(mapping.lastIndexOf("*/") + 2);
 
         mapper = new Mapper(mapping, new ArrayList<>(), true);
+        mapper.findAndRegisterPlugins();
+
         mapped = mapper.transform(data, new HashMap<>(), "application/java");
 
         result = mapped.getContentsAsObject();
@@ -75,6 +75,8 @@ public class JavaWriterTest {
         //Test calling write() function
         String mapping = TestResourceReader.readFileAsString("writeJavaFunctionTest.ds");
         Mapper mapper = new Mapper(mapping, new ArrayList<>(), true);
+        mapper.findAndRegisterPlugins();
+
         try {
             mapper.transform(data, new HashMap<>(), "application/java");
             fail("Should not succeed");

--- a/src/test/java/com/datasonnet/JsonPathTest.java
+++ b/src/test/java/com/datasonnet/JsonPathTest.java
@@ -15,7 +15,7 @@ public class JsonPathTest {
     void testJsonPathSelector() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("jsonPathTest.json");
 
-        Mapper mapper = new Mapper("DS.JsonPath.select(payload, \"$..book[-2:]..author\")[0]", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.JsonPath.select(payload, \"$..book[-2:]..author\")[0]");
         String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").getContentsAsString();
 
         assertEquals(mappedJson, "\"Herman Melville\"");
@@ -25,7 +25,7 @@ public class JsonPathTest {
     void testJsonPathArrSelector() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("jsonPathArrTest.json");
 
-        Mapper mapper = new Mapper("std.length(DS.JsonPath.select(payload, \"$..language[?(@.name == 'Java')]\")) > 0", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("std.length(DS.JsonPath.select(payload, \"$..language[?(@.name == 'Java')]\")) > 0");
         String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").getContentsAsString();
 
         assertEquals(mappedJson, "true");

--- a/src/test/java/com/datasonnet/LocalDateTimeTest.java
+++ b/src/test/java/com/datasonnet/LocalDateTimeTest.java
@@ -14,7 +14,7 @@ public class LocalDateTimeTest {
 
     @Test
     void testOffset() {
-        Mapper mapper = new Mapper("DS.LocalDateTime.offset(\"2019-07-22T21:00:00\", \"P1Y1D\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.offset(\"2019-07-22T21:00:00\", \"P1Y1D\")");
         String offsetDate = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("2020-07-23T21:00:00".equals(offsetDate));
 //        System.out.println("Offset date is " + offsetDate);
@@ -24,7 +24,7 @@ public class LocalDateTimeTest {
     void testNow() {
         Instant before = Instant.now();
 
-        Mapper mapper = new Mapper("DS.LocalDateTime.now()", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.now()");
         // getting rid of quotes so the Instant parser works
         String mapped = mapper.transform("{}").replaceAll("\"", "");
         String today = java.time.LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
@@ -37,7 +37,7 @@ public class LocalDateTimeTest {
 
     @Test
     void testFormat() {
-        Mapper mapper = new Mapper("DS.LocalDateTime.format(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"d MMM uuuu\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.format(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"d MMM uuuu\")");
         String formattedDate = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("4 Jul 2019".equals(formattedDate));
@@ -45,7 +45,7 @@ public class LocalDateTimeTest {
 
     @Test
     void testCompare() {
-        Mapper mapper = new Mapper("DS.LocalDateTime.compare(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.LocalDateTime.compare(\"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\", \"2019-07-04T21:00:00\", \"yyyy-MM-dd'T'HH:mm:ss\")");
         String compareResult = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("0".equals(compareResult));

--- a/src/test/java/com/datasonnet/MapperTest.java
+++ b/src/test/java/com/datasonnet/MapperTest.java
@@ -21,7 +21,7 @@ public class MapperTest {
     @ParameterizedTest
     @MethodSource("simpleProvider")
     void simple(String jsonnet, String json, String expected) {
-        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        Mapper mapper = new Mapper(jsonnet);
         assertEquals(expected, mapper.transform(json));
     }
 
@@ -115,7 +115,7 @@ public class MapperTest {
     @Test
     void nonJsonArguments() {
         Mapper mapper = new Mapper("argument", Arrays.asList("argument"), true);
-        mapper.findAndRegisterPlugins();
+
 
         Map<String, Document> map = Collections.singletonMap("argument", new StringDocument("value", "text/plain"));
 
@@ -147,7 +147,7 @@ public class MapperTest {
         variables.put("v1", new StringDocument("v1value", "text/plain"));
 
         Mapper mapper = new Mapper(datasonnet, variables.keySet(), true);
-        mapper.findAndRegisterPlugins();
+
 
         String mapped = mapper.transform(new StringDocument(jsonData, "application/json"), variables, "application/json").getContentsAsString();
 
@@ -158,7 +158,7 @@ public class MapperTest {
                      "output.preserveOrder=false\n*/\n" + datasonnet;
 
         mapper = new Mapper(datasonnet, variables.keySet(), true);
-        mapper.findAndRegisterPlugins();
+
 
         mapped = mapper.transform(new StringDocument(jsonData, "application/json"), variables, "application/json").getContentsAsString();
 

--- a/src/test/java/com/datasonnet/MapperTest.java
+++ b/src/test/java/com/datasonnet/MapperTest.java
@@ -18,11 +18,6 @@ import java.util.stream.Stream;
 
 public class MapperTest {
 
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
-
     @ParameterizedTest
     @MethodSource("simpleProvider")
     void simple(String jsonnet, String json, String expected) {
@@ -119,8 +114,8 @@ public class MapperTest {
 
     @Test
     void nonJsonArguments() {
-        DataFormatService.getInstance().findAndRegisterPlugins();
         Mapper mapper = new Mapper("argument", Arrays.asList("argument"), true);
+        mapper.findAndRegisterPlugins();
 
         Map<String, Document> map = Collections.singletonMap("argument", new StringDocument("value", "text/plain"));
 
@@ -152,6 +147,8 @@ public class MapperTest {
         variables.put("v1", new StringDocument("v1value", "text/plain"));
 
         Mapper mapper = new Mapper(datasonnet, variables.keySet(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(new StringDocument(jsonData, "application/json"), variables, "application/json").getContentsAsString();
 
         assertEquals("{\"z\":\"z\",\"a\":\"a\",\"v2\":\"v2value\",\"v1\":\"v1value\",\"y\":\"y\",\"t\":\"t\"}", mapped.trim());
@@ -161,6 +158,8 @@ public class MapperTest {
                      "output.preserveOrder=false\n*/\n" + datasonnet;
 
         mapper = new Mapper(datasonnet, variables.keySet(), true);
+        mapper.findAndRegisterPlugins();
+
         mapped = mapper.transform(new StringDocument(jsonData, "application/json"), variables, "application/json").getContentsAsString();
 
         assertEquals("{\"a\":\"a\",\"t\":\"t\",\"v1\":\"v1value\",\"v2\":\"v2value\",\"y\":\"y\",\"z\":\"z\"}", mapped.trim());

--- a/src/test/java/com/datasonnet/RegexTest.java
+++ b/src/test/java/com/datasonnet/RegexTest.java
@@ -26,7 +26,7 @@ public class RegexTest {
     @ParameterizedTest
     @MethodSource("jsonAssertProvider")
     void testRegexJSON(String jsonnet, String expected) throws JSONException {
-        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), Collections.emptyMap(), true);
+        Mapper mapper = new Mapper(jsonnet);
         String result = mapper.transform("{}");
         JSONAssert.assertEquals(expected, result, true);
     }
@@ -34,7 +34,7 @@ public class RegexTest {
     @ParameterizedTest
     @MethodSource("assertEqualsProvider")
     void testRegexStr(String jsonnet, String expected) throws JSONException {
-        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), Collections.emptyMap(), true);
+        Mapper mapper = new Mapper(jsonnet);
         String result = mapper.transform("{}");
         assertEquals(expected, result);
     }
@@ -67,7 +67,7 @@ public class RegexTest {
     @Test
     void testRegexGlobalReplaceWithFunction() throws Exception {
         String jsonnet = TestResourceReader.readFileAsString("regexGlobalReplaceWithFunction.ds");
-        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), Collections.emptyMap(), true);
+        Mapper mapper = new Mapper(jsonnet);
         String result = mapper.transform("{}");
         assertEquals("\"xxx4yyy16zzz36aaa\"", result);
     }

--- a/src/test/java/com/datasonnet/UtilLibraryTest.java
+++ b/src/test/java/com/datasonnet/UtilLibraryTest.java
@@ -14,15 +14,15 @@ public class UtilLibraryTest {
     void testDuplicates() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("utilLibDuplicatesTest.json");
 
-        Mapper mapper = new Mapper("DS.Util.duplicates(payload.primitive)", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.Util.duplicates(payload.primitive)");
         String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").getContentsAsString();
         assertEquals(mappedJson, "[\"hello\",\"world\"]");
 
-        mapper = new Mapper("DS.Util.duplicates(payload.complex, function(x) x.language.name)", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Util.duplicates(payload.complex, function(x) x.language.name)");
         mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").getContentsAsString();
         assertEquals(mappedJson, "[{\"language\":{\"name\":\"Java8\",\"version\":\"1.8.0\"}}]");
 
-        mapper = new Mapper("DS.Util.duplicates(payload.moreComplex, function(x) std.substr(x.language.version, 0, 3))", Collections.emptyList(), true);
+        mapper = new Mapper("DS.Util.duplicates(payload.moreComplex, function(x) std.substr(x.language.version, 0, 3))");
         mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").getContentsAsString();
         assertEquals(mappedJson, "[{\"language\":{\"name\":\"Java1.8\",\"version\":\"1.8_152\"}}]");
     }
@@ -36,7 +36,7 @@ public class UtilLibraryTest {
     @Test
     void testReverse() throws Exception {
         String jsonData = "[\"a\",\"b\",\"c\",\"d\"]";
-        Mapper mapper = new Mapper("DS.Util.reverse(payload)", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.Util.reverse(payload)");
         String mappedJson = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/json").getContentsAsString();
 
         assertEquals(mappedJson, "[\"d\",\"c\",\"b\",\"a\"]");
@@ -66,7 +66,7 @@ public class UtilLibraryTest {
     private void testDS(String dsFileName, String input) throws Exception {
         String ds = TestResourceReader.readFileAsString(dsFileName);
 
-        Mapper mapper = new Mapper(ds, Collections.emptyList(), true);
+        Mapper mapper = new Mapper(ds);
         String mappedJson = mapper.transform(new StringDocument(input, "application/json"), Collections.emptyMap(), "application/json").getContentsAsString();
 
         assertEquals(mappedJson, "true");

--- a/src/test/java/com/datasonnet/XMLPropertyTest.java
+++ b/src/test/java/com/datasonnet/XMLPropertyTest.java
@@ -31,7 +31,7 @@ public class XMLPropertyTest {
     @Property
     public void reversible(@From(XMLGenerator.class) @Dictionary("xml.dict") Document dom) throws Exception {
         String xml = XMLDocumentUtils.documentToString(dom);
-        Mapper mapper = new Mapper("DS.Formats.write(DS.Formats.read(payload, \"application/xml\"), \"application/xml\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.Formats.write(DS.Formats.read(payload, \"application/xml\"), \"application/xml\")");
         String output = mapper.transform(new StringDocument(xml, "application/xml"), Collections.emptyMap(), "application/xml").getContentsAsString();
         DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document parsed = db.parse(new ByteArrayInputStream(output.getBytes("UTF-8")));

--- a/src/test/java/com/datasonnet/XMLPropertyTest.java
+++ b/src/test/java/com/datasonnet/XMLPropertyTest.java
@@ -26,10 +26,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(JUnitQuickcheck.class)
 public class XMLPropertyTest {
 
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
+
 
     @Property
     public void reversible(@From(XMLGenerator.class) @Dictionary("xml.dict") Document dom) throws Exception {

--- a/src/test/java/com/datasonnet/XMLReaderTest.java
+++ b/src/test/java/com/datasonnet/XMLReaderTest.java
@@ -16,11 +16,6 @@ import java.util.Collections;
 
 public class XMLReaderTest {
 
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
-
     @Test
     void testNonAscii() throws Exception {
         mapAndAssert("xmlNonAscii.xml", "xmlNonAscii.json");
@@ -34,6 +29,8 @@ public class XMLReaderTest {
         String jsonnet = "/** DataSonnet\nversion=1.0\ninput.payload.application/xml.NamespaceDeclarations.b=http://example.com/1\n*/\npayload";
 
         Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(new StringDocument(xml, "application/xml"), Collections.emptyMap(), "application/json").getContentsAsString();
 
         // the b namespace must have been remapped
@@ -53,6 +50,8 @@ public class XMLReaderTest {
         String expectedJson = TestResourceReader.readFileAsString("readXMLExtTest.json");
 
         Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), Collections.emptyMap(), "application/json").getContentsAsString();
 
         JSONAssert.assertEquals(expectedJson, mappedJson, false);
@@ -77,8 +76,9 @@ public class XMLReaderTest {
         String xmlData = TestResourceReader.readFileAsString(inputFileName);
         String expectedJson = TestResourceReader.readFileAsString(expectedFileName);
 
-
         Mapper mapper = new Mapper("payload", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), Collections.emptyMap(), "application/json").getContentsAsString();
         JSONAssert.assertEquals(expectedJson, mappedJson, false);
     }

--- a/src/test/java/com/datasonnet/XMLReaderTest.java
+++ b/src/test/java/com/datasonnet/XMLReaderTest.java
@@ -28,8 +28,8 @@ public class XMLReaderTest {
 
         String jsonnet = "/** DataSonnet\nversion=1.0\ninput.payload.application/xml.NamespaceDeclarations.b=http://example.com/1\n*/\npayload";
 
-        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(jsonnet);
+
 
         String mapped = mapper.transform(new StringDocument(xml, "application/xml"), Collections.emptyMap(), "application/json").getContentsAsString();
 
@@ -49,8 +49,8 @@ public class XMLReaderTest {
         String jsonnet = TestResourceReader.readFileAsString("readXMLExtTest.ds");
         String expectedJson = TestResourceReader.readFileAsString("readXMLExtTest.json");
 
-        Mapper mapper = new Mapper(jsonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(jsonnet);
+
 
         String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), Collections.emptyMap(), "application/json").getContentsAsString();
 
@@ -76,8 +76,8 @@ public class XMLReaderTest {
         String xmlData = TestResourceReader.readFileAsString(inputFileName);
         String expectedJson = TestResourceReader.readFileAsString(expectedFileName);
 
-        Mapper mapper = new Mapper("payload", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper("payload");
+
 
         String mappedJson = mapper.transform(new StringDocument(xmlData, "application/xml"), Collections.emptyMap(), "application/json").getContentsAsString();
         JSONAssert.assertEquals(expectedJson, mappedJson, false);

--- a/src/test/java/com/datasonnet/XMLWriterTest.java
+++ b/src/test/java/com/datasonnet/XMLWriterTest.java
@@ -21,17 +21,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class XMLWriterTest {
 
-    @BeforeAll
-    static void registerPlugins() throws Exception {
-        DataFormatService.getInstance().findAndRegisterPlugins();
-    }
-
     @Test
     void testOverrideNamespaces() throws Exception {
         String json = "{\"b:a\":{\"@xmlns\":{\"b\":\"http://example.com/1\",\"b1\":\"http://example.com/2\"},\"b1:b\":{}}}";
         String datasonnet = TestResourceReader.readFileAsString("xmlOverrideNamespaces.ds");
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(new StringDocument(json, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         // original mapping is gone
@@ -54,6 +51,8 @@ public class XMLWriterTest {
         String datasonnet = TestResourceReader.readFileAsString("xmlNamespaceBump.ds");
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mapped = mapper.transform(new StringDocument(json, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
 
@@ -76,6 +75,8 @@ public class XMLWriterTest {
         String expectedXml = TestResourceReader.readFileAsString("readXMLExtTest.xml");
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         Map<String, String> namespaces = new HashMap<>();
@@ -92,6 +93,8 @@ public class XMLWriterTest {
         String datasonnet = TestResourceReader.readFileAsString("xmlNonAscii.ds");
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         assertEquals(expectedXml, mappedXml);
@@ -107,6 +110,8 @@ public class XMLWriterTest {
         String datasonnet = TestResourceReader.readFileAsString("xmlNonAscii.ds");//Reuse existing one to avoid duplication
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
@@ -120,6 +125,8 @@ public class XMLWriterTest {
         Mapper mapper = new Mapper("local params = {\n" +
                 "    \"XmlVersion\" : \"1.1\"\n" +
                 "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
@@ -132,6 +139,8 @@ public class XMLWriterTest {
         String datasonnet = TestResourceReader.readFileAsString("xmlEmptyElementsNull.ds");
 
         Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
@@ -140,6 +149,8 @@ public class XMLWriterTest {
         datasonnet = TestResourceReader.readFileAsString("xmlEmptyElementsNoNull.ds");
 
         mapper = new Mapper(datasonnet, Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
@@ -154,6 +165,8 @@ public class XMLWriterTest {
                 "output.application/xml.OmitXmlDeclaration=true\n" +
                 "*/\n" +
                 "payload", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
         assertFalse(mappedXml.contains("<?xml"));
@@ -163,6 +176,7 @@ public class XMLWriterTest {
                 "output.application/xml.OmitXmlDeclaration=false\n" +
                 "*/\n" +
                 "payload", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
 
         mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -174,6 +188,8 @@ public class XMLWriterTest {
         String jsonData = TestResourceReader.readFileAsString("xmlRoot.json");
 
         Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         try {
             String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
             fail("Must fail to transform");
@@ -186,6 +202,8 @@ public class XMLWriterTest {
                 "output.application/xml.RootElement=TestRoot\n" +
                 "*/\n" +
                 "payload", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         try {
             String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
         } catch(IllegalArgumentException e) {
@@ -197,6 +215,8 @@ public class XMLWriterTest {
         String jsonData = TestResourceReader.readFileAsString("test.json");
 
         Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")", Collections.emptyList(), true);
+        mapper.findAndRegisterPlugins();
+
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
 

--- a/src/test/java/com/datasonnet/XMLWriterTest.java
+++ b/src/test/java/com/datasonnet/XMLWriterTest.java
@@ -26,8 +26,8 @@ public class XMLWriterTest {
         String json = "{\"b:a\":{\"@xmlns\":{\"b\":\"http://example.com/1\",\"b1\":\"http://example.com/2\"},\"b1:b\":{}}}";
         String datasonnet = TestResourceReader.readFileAsString("xmlOverrideNamespaces.ds");
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
+
 
         String mapped = mapper.transform(new StringDocument(json, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -50,8 +50,8 @@ public class XMLWriterTest {
 
         String datasonnet = TestResourceReader.readFileAsString("xmlNamespaceBump.ds");
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
+
 
         String mapped = mapper.transform(new StringDocument(json, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -74,8 +74,8 @@ public class XMLWriterTest {
         String datasonnet = TestResourceReader.readFileAsString("writeXMLExtTest.ds");
         String expectedXml = TestResourceReader.readFileAsString("readXMLExtTest.xml");
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
+
 
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -92,8 +92,7 @@ public class XMLWriterTest {
         String expectedXml = TestResourceReader.readFileAsString("xmlNonAscii.xml");
         String datasonnet = TestResourceReader.readFileAsString("xmlNonAscii.ds");
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
 
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -109,8 +108,7 @@ public class XMLWriterTest {
         String expectedXml = TestResourceReader.readFileAsString("xmlCDATA.xml");
         String datasonnet = TestResourceReader.readFileAsString("xmlNonAscii.ds");//Reuse existing one to avoid duplication
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
 
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -124,8 +122,8 @@ public class XMLWriterTest {
 
         Mapper mapper = new Mapper("local params = {\n" +
                 "    \"XmlVersion\" : \"1.1\"\n" +
-                "};DS.Formats.write(payload, \"application/xml\", params)", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+                "};DS.Formats.write(payload, \"application/xml\", params)");
+
 
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -138,8 +136,7 @@ public class XMLWriterTest {
         String expectedXml = TestResourceReader.readFileAsString("xmlEmptyElementsNull.xml");
         String datasonnet = TestResourceReader.readFileAsString("xmlEmptyElementsNull.ds");
 
-        Mapper mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper(datasonnet);
 
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -148,8 +145,8 @@ public class XMLWriterTest {
         expectedXml = TestResourceReader.readFileAsString("xmlEmptyElementsNoNull.xml");
         datasonnet = TestResourceReader.readFileAsString("xmlEmptyElementsNoNull.ds");
 
-        mapper = new Mapper(datasonnet, Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        mapper = new Mapper(datasonnet);
+
 
         mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -164,8 +161,7 @@ public class XMLWriterTest {
                 "version=1.0\n" +
                 "output.application/xml.OmitXmlDeclaration=true\n" +
                 "*/\n" +
-                "payload", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+                "payload");
 
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -175,8 +171,7 @@ public class XMLWriterTest {
                 "version=1.0\n" +
                 "output.application/xml.OmitXmlDeclaration=false\n" +
                 "*/\n" +
-                "payload", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+                "payload");
 
         mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
 
@@ -187,8 +182,8 @@ public class XMLWriterTest {
     void testXMLRoot() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("xmlRoot.json");
 
-        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")");
+
 
         try {
             String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
@@ -201,8 +196,7 @@ public class XMLWriterTest {
                 "version=1.0\n" +
                 "output.application/xml.RootElement=TestRoot\n" +
                 "*/\n" +
-                "payload", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+                "payload");
 
         try {
             String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
@@ -214,11 +208,9 @@ public class XMLWriterTest {
     void simpleJsonTest() throws Exception {
         String jsonData = TestResourceReader.readFileAsString("test.json");
 
-        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")", Collections.emptyList(), true);
-        mapper.findAndRegisterPlugins();
+        Mapper mapper = new Mapper("DS.Formats.write(payload, \"application/xml\")");
 
         String mappedXml = mapper.transform(new StringDocument(jsonData, "application/json"), Collections.emptyMap(), "application/xml").getContentsAsString();
-
 
         assertTrue(mappedXml.contains("<?xml"));
     }

--- a/src/test/java/com/datasonnet/ZonedDateTimeTest.java
+++ b/src/test/java/com/datasonnet/ZonedDateTimeTest.java
@@ -12,7 +12,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testOffset() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.offset(\"2019-07-22T21:00:00Z\", \"P1Y1D\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.offset(\"2019-07-22T21:00:00Z\", \"P1Y1D\")");
         String offsetDate = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("2020-07-23T21:00:00Z".equals(offsetDate));
 //        System.out.println("Offset date is " + offsetDate);
@@ -22,7 +22,7 @@ public class ZonedDateTimeTest {
     void testNow() {
         Instant before = Instant.now();
 
-        Mapper mapper = new Mapper("DS.ZonedDateTime.now()", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.now()");
         // getting rid of quotes so the Instant parser works
         Instant mapped = Instant.parse(mapper.transform("{}").replaceAll("\"", ""));
 
@@ -34,7 +34,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testFormat() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.format(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"d MMM uuuu\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.format(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"d MMM uuuu\")");
         String formattedDate = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("4 Jul 2019".equals(formattedDate));
@@ -42,7 +42,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testCompare() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.compare(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.compare(\"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\", \"2019-07-04T21:00:00Z\", \"yyyy-MM-dd'T'HH:mm:ssVV\")");
         String compareResult = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("Formatted date is " + formattedDate);
         assertTrue("0".equals(compareResult));
@@ -50,7 +50,7 @@ public class ZonedDateTimeTest {
 
     @Test
     void testTimezone() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.changeTimeZone(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\", \"America/Los_Angeles\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.changeTimeZone(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\", \"America/Los_Angeles\")");
         String newTimezone = mapper.transform("{}").replaceAll("\"", "");
         //System.out.println("New date is " + newTimezone);
         assertTrue("2019-07-04T19:00:00-0700".equals(newTimezone));
@@ -58,11 +58,11 @@ public class ZonedDateTimeTest {
 
     @Test
     void testLocalDT() {
-        Mapper mapper = new Mapper("DS.ZonedDateTime.toLocalDate(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")", Collections.emptyList(), true);
+        Mapper mapper = new Mapper("DS.ZonedDateTime.toLocalDate(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")");
         String newDate = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("2019-07-04".equals(newDate));
 
-        mapper = new Mapper("DS.ZonedDateTime.toLocalTime(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")", Collections.emptyList(), true);
+        mapper = new Mapper("DS.ZonedDateTime.toLocalTime(\"2019-07-04T21:00:00-0500\", \"yyyy-MM-dd'T'HH:mm:ssZ\")");
         String newTime = mapper.transform("{}").replaceAll("\"", "");
         assertTrue("21:00:00".equals(newTime));
 


### PR DESCRIPTION
The basic pattern for code that needs to use plugins and wants to auto load them is:

```java
Mapper mapper = ...
mapper.findAndRegisterPlugins()
```